### PR TITLE
Log error and stack trace & release 2.0.0.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image: google/dart:2.12-beta
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 2.12.0
 
       - name: Download pub.dev credentials
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,12 @@ jobs:
     name: Flutter ${{ matrix.channel }}${{ matrix.version }}
 
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         include:
-            - version: '1.24.x'
+            - version: '2.0.x'
             - channel: stable
             - channel: beta
             - channel: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0
+
+- Bump minimum SDK version to 2.12.
+- Depend on flutter_bugfender 2.0.0-web.1
+- Depend on logging 1.0.1
+- Log error and stack trace if present in the log record.
+
 # 2.0.0-nullsafety.0
 
 - Bump minimum SDK version to 2.12 prerelease.

--- a/lib/logging_bugfender.dart
+++ b/lib/logging_bugfender.dart
@@ -67,9 +67,6 @@ class LoggingBugfenderListener {
 
   /// Registers a [Logger] listener to the Bugfender.
   void listen(Logger logger) {
-    String _mapRecord(LogRecord record) =>
-        '[${record.level.name}] ${record.loggerName}: ${record.message}';
-
     logger.onRecord.listen((record) {
       if (record.level >= Level.SEVERE) {
         FlutterBugfender.fatal(_mapRecord(record));
@@ -81,6 +78,14 @@ class LoggingBugfenderListener {
         FlutterBugfender.trace(_mapRecord(record));
       }
     });
+  }
+
+  String _mapRecord(LogRecord record) {
+    var log = '[${record.level.name}] ${record.loggerName}: ${record.message}';
+    if (record.error != null) log += '\n${record.error}';
+    if (record.stackTrace != null) log += '\n${record.stackTrace}';
+
+    return log;
   }
 
   /// Sets the custom data with a specified `key` for Bugfender on this device.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,11 @@ version: 2.0.0-nullsafety.0
 homepage: https://github.com/leancodepl/logging_bugfender
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  flutter_bugfender: ^2.0.0-nullsafety.0
-  logging: ^1.0.0-nullsafety.0
+  flutter_bugfender: ^2.0.0-web.1
+  logging: ^1.0.1
 
 dev_dependencies:
-  lint: ^1.3.0
+  lint: ^1.5.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logging_bugfender
 description: A library helping integrate Bugfender with the logging package.
-version: 2.0.0-nullsafety.0
+version: 2.0.0
 homepage: https://github.com/leancodepl/logging_bugfender
 
 environment:


### PR DESCRIPTION
- Bump minimum SDK version to 2.12.
- Depend on flutter_bugfender 2.0.0-web.1
- Depend on logging 1.0.1
- Log error and stack trace if present in the log record.